### PR TITLE
add support for wrangler dev

### DIFF
--- a/template.js
+++ b/template.js
@@ -57,7 +57,7 @@ const template = `
   }
 
   const url = new URL(window.location)
-  url.protocol = "wss"
+  url.protocol = document.location.protocol === "http:" ? "ws://" : "wss://";
   url.pathname = "/ws"
   websocket(url)
 


### PR DESCRIPTION
This example wasn't originally working with `wrangler dev`. An error code of 1015 was being returned when the websocket connection was being established. (TLS Error)

This seems to fix it.